### PR TITLE
Doc updates

### DIFF
--- a/.github/workflows/docs_aws.yml
+++ b/.github/workflows/docs_aws.yml
@@ -1,9 +1,8 @@
 name: Sphinx build for AWS
 
 on:
-  push:
-    branches: 
-      - release
+  release:
+    types: [published]
 
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The primary intent is for use as a central device for benchtop testing, continuo
 
 1. Refer to the [hardware setup](https://github.com/dialog-semiconductor/py_ble_manager/blob/main/docs/source/hardware_setup.rst) to setup the jumpers on your development kit.
 
-2. Call: `pip install py-ble-manager` to install the `py_ble_manager` package and its dependencies.
+2. Call: `pip install py-ble-manager[dev]` to install the `py_ble_manager` package and its dependencies.
 
     > **_NOTE:_**
       Specifying [dev] will install optional dependency: [prompt_toolkit](https://pypi.org/project/prompt-toolkit/).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,8 +11,6 @@ from importlib.metadata import version as get_version
 project = 'py_ble_manager'
 copyright = '2023, Patrick Murphy'
 author = 'Patrick Murphy'
-version = get_version("py_ble_manager")
-release = version
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,6 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-from importlib.metadata import version as get_version
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -3,7 +3,7 @@ Quick Start
 
 #. Refer to the :doc:`hardware_setup` to setup the jumpers on your development kit.
 
-#. Call: ``pip install "py_ble_manager[dev] @ git+https://github.com/dialog-semiconductor/py_ble_manager.git`` to install the ``py_ble_manager`` package and its dependencies.
+#. Call: ``pip install "py-ble-manager[dev]`` to install the ``py_ble_manager`` package and its dependencies.
 
     .. note:: 
       Specifying [dev] will install optional dependency: `prompt_toolkit <https://pypi.org/project/prompt-toolkit/>`_.
@@ -11,6 +11,13 @@ Quick Start
 
     .. note:: 
       This library requires Python v3.10.5 or later.
+
+    .. note:: 
+      It is recommended to install the library using a virtual environment. 
+      To setup a virtual environment using [venv](https://docs.python.org/3/library/venv.html) call: `$ python -m venv ./<name_of_your_env>`. 
+      Note to create a virtual environment that uses Python 3.10.5, you must already have Python 3.10.5 downloaded on your computer. 
+      To use the above command to create a Python 3.10.5 environment, Python 3.10.5 must be configured in your PATH. 
+      You can download it from the [python website](https://www.python.org/downloads/release/python-3105/).
 
 #. :doc:`Download <programming_util>` the py_ble_manager enabled firmware binary to the development kit by calling the ``py_ble_manager_programmer`` utility from the terminal.
     

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -3,7 +3,7 @@ Quick Start
 
 #. Refer to the :doc:`hardware_setup` to setup the jumpers on your development kit.
 
-#. Call: ``pip install "py-ble-manager[dev]`` to install the ``py_ble_manager`` package and its dependencies.
+#. Call: ``pip install py-ble-manager[dev]`` to install the ``py_ble_manager`` package and its dependencies.
 
     .. note:: 
       Specifying [dev] will install optional dependency: `prompt_toolkit <https://pypi.org/project/prompt-toolkit/>`_.
@@ -14,10 +14,10 @@ Quick Start
 
     .. note:: 
       It is recommended to install the library using a virtual environment. 
-      To setup a virtual environment using [venv](https://docs.python.org/3/library/venv.html) call: `$ python -m venv ./<name_of_your_env>`. 
+      To setup a virtual environment using `venv <https://docs.python.org/3/library/venv.html>`_ call: `$ python -m venv ./<name_of_your_env>`. 
       Note to create a virtual environment that uses Python 3.10.5, you must already have Python 3.10.5 downloaded on your computer. 
       To use the above command to create a Python 3.10.5 environment, Python 3.10.5 must be configured in your PATH. 
-      You can download it from the [python website](https://www.python.org/downloads/release/python-3105/).
+      You can download it from the `python website <https://www.python.org/downloads/release/python-3105/>`_.
 
 #. :doc:`Download <programming_util>` the py_ble_manager enabled firmware binary to the development kit by calling the ``py_ble_manager_programmer`` utility from the terminal.
     

--- a/examples/central/3_central_crash_info/README.md
+++ b/examples/central/3_central_crash_info/README.md
@@ -1,7 +1,7 @@
 # central_crash_info
 
 This example provides a command line interface to retreive crash information from a DA14531 peripheral running the Debug Crash Info Service. See the
-[Debug Crash Info Github](https://github.com/Renesas-US-Connectivity/dlg_crash_info) for additional details.
+[firmware Github](https://github.com/dialog-semiconductor/BLE_SDK6_examples/tree/main/features/dlg_crash_info) for additional details.
 
 You can run it with:
 


### PR DESCRIPTION
Readme updated to include optional dependency [dev] which will install prompt_toolkit: 61194cef9c7f6f09684aabde1d51be14834da283
Modified docs_aws action to run when release published: 6d209613d8a2ef2a504ea59795ca6e731abedab5
Fixed github link to dlg_crash_info example in readme for central_crash_info.py: 4821ee405ef0ec6cb172cd76bafca1a5cd475ed6
Removed versioning from sphinx docs: bf4f0b6a5a0b3a346d569ce81c9edd22b192acbe
Fixes to quickstart.rst to align with github readme: e8cf340cecf21e48f4e35ccac4ada8496d28e674
Corrected links in quickstart.rst: 811b26b8a7d324cc580b8702a49dba3bf4ce837f